### PR TITLE
add github action to upload data to s3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: Reload Data (Staging Environment)
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "**.csv"
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Upload file to bucket
+        uses: Hyperobjekt/s3-upload-github-action@master
+        with:
+          args: --acl public-read
+        env:
+          FILE: "./data/tulsa_eviction_cases.csv"
+          AWS_REGION: "us-east-1"
+          S3_BUCKET: "tulsastack-stagingdatastore42145388-1bvtz4nrc4k1i"
+          S3_KEY: "source.csv"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,24 @@
+name: Reload Data (Production Environment)
+on:
+  push:
+    branches:
+      - "production"
+    paths:
+      - "**.csv"
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Upload file to bucket
+        uses: Hyperobjekt/s3-upload-github-action@master
+        with:
+          args: --acl public-read
+        env:
+          FILE: "./data/tulsa_eviction_cases.csv"
+          AWS_REGION: "us-east-1"
+          S3_BUCKET: "tulsastack-productiondatastore5e36f90b-p6jhplwoo5aa"
+          S3_KEY: "source.csv"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This will automatically upload `tulsa_eviction_cases.csv` to the CPAL S3 bucket that is used by the front end to display the underlying data. I had been manually updating this previously.

Pushes to `main` branch will upload the data to the staging environment, which is the one we have currently been sharing.
Pushes to `production` branch will upload the data to the production environment, which is not used yet.

These can be modified to fit your workflow as you'd like.

I believe you can manually trigger the staging workflow from the repo actions, and have it upload the data. If that doesn't work, you may need to re-upload the data to the repo. Once that happens, I'll verify the results and reach out if there are any issues.